### PR TITLE
Add validation method to enforce required flag

### DIFF
--- a/acf-focal_point-v5.php
+++ b/acf-focal_point-v5.php
@@ -349,8 +349,34 @@ class acf_field_focal_point extends acf_field {
 		
 		return $value;
 	}
-	
-	
+
+	/*
+	*  validate_value()
+	*
+	*  This filter is used to perform validation on the value prior to saving.
+	*  All values are validated regardless of the field's required setting. This allows you to validate and return
+	*  messages to the user if the value is not correct
+	*
+	*  @type	filter
+	*  @date	11/02/2014
+	*  @since	5.0.0
+	*
+	*  @param	$valid (boolean) validation status based on the value and the field's required setting
+	*  @param	$value (mixed) the $_POST value
+	*  @param	$field (array) the field array holding all the field options
+	*  @param	$input (string) the corresponding input name for $_POST value
+	*  @return	$valid
+	*/
+
+	function validate_value( $valid, $value, $field, $input ){
+
+		if ($field['required'] === 1 && empty($value['id'])) {
+			return false;
+		}
+
+		return $valid;
+	}
+
 }
 
 


### PR DESCRIPTION
Great work on this plugin!

Our QA noticed that the "required" flag wasn't being honored, allowing a user to save a page even though no image had been uploaded. After poking around a little bit, I noticed that the `validate_value` hadn't been implemented. Here's a quick stab and getting it operational.

Thanks for the kick ass work!
Eran
